### PR TITLE
refactor: modularize med calculator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "med-cal",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node src/selfTests.js"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -1,0 +1,5 @@
+import MedCalcDashboard from '../components/MedCalcDashboard.jsx';
+
+export default function Page() {
+  return <MedCalcDashboard />;
+}

--- a/src/components/CalculatorCard.jsx
+++ b/src/components/CalculatorCard.jsx
@@ -1,0 +1,104 @@
+'use client';
+import { useEffect, useState } from 'react';
+import InputField from './InputField.jsx';
+import SectionTitle from './SectionTitle.jsx';
+import ResultRow from './ResultRow.jsx';
+import Card from './Card.jsx';
+import { round, copyToClipboard } from '../lib/utils.js';
+
+export default function CalculatorCard({ def, values, setValues, favorites, setFavorites, last, setLast }) {
+  const [results, setResults] = useState({});
+  const [showFormula, setShowFormula] = useState(false);
+
+  useEffect(() => {
+    const out = def.compute(values || {});
+    setResults(out || {});
+    const hasValid = out && Object.values(out).some((v) => v !== null && v !== undefined && v !== '');
+    if (hasValid) {
+      setLast({ results: out, at: Date.now(), inputs: values });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(values)]);
+
+  const isFav = favorites.includes(def.id);
+  const toggleFav = () => {
+    setFavorites((prev) => (isFav ? prev.filter((x) => x !== def.id) : [...prev, def.id]));
+  };
+
+  const copyResult = async () => {
+    const lines = Object.entries(results)
+      .map(([k, v]) => `${k}: ${typeof v === 'number' ? round(v, 2) : v}`)
+      .join('\n');
+    const text = `${def.name}\n${lines}`;
+    const ok = await copyToClipboard(text);
+    alert(ok ? 'Copied results to clipboard' : 'Copy failed – your browser may block clipboard access.');
+  };
+
+  const fmtTime = (t) => new Date(t).toLocaleString();
+
+  return (
+    <Card
+      title={def.name}
+      subtitle={def.refs?.[0]}
+      isFav={isFav}
+      onToggleFav={toggleFav}
+      actions={
+        <div className="flex gap-2">
+          <button
+            onClick={() => setShowFormula((s) => !s)}
+            className="rounded-full px-3 py-1 text-xs border bg-white border-gray-300"
+          >
+            {showFormula ? 'ซ่อนสูตร' : 'สูตร/ที่มา'}
+          </button>
+          <button onClick={copyResult} className="rounded-full px-3 py-1 text-xs border bg-white border-gray-300">
+            Copy
+          </button>
+        </div>
+      }
+    >
+      {showFormula && (
+        <div className="mb-3 text-[13px] text-gray-700 bg-gray-50 border border-gray-200 rounded-xl p-3">
+          <div className="font-medium mb-1">สูตรคำนวณ</div>
+          <div className="whitespace-pre-wrap leading-snug">{(def.formula || def.refs?.join('\n'))}</div>
+          {def.notes && <div className="mt-2 text-[12px] text-gray-500">หมายเหตุ: {def.notes}</div>}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 gap-3">
+        {def.fields.map((f) => (
+          <InputField key={f.key} field={f} value={values?.[f.key]} onChange={(k, v) => setValues((prev) => ({ ...prev, [k]: v }))} />
+        ))}
+      </div>
+
+      <div className="mt-4 border-t pt-3">
+        <SectionTitle>ผลลัพธ์ (คำนวณจากอินพุตปัจจุบัน)</SectionTitle>
+        <div className="flex flex-col gap-1">
+          {Object.keys(results || {}).length === 0 && (
+            <div className="text-sm text-gray-500">กรอกข้อมูลเพื่อคำนวณ</div>
+          )}
+          {Object.entries(results || {}).map(([k, v]) => (
+            <ResultRow key={k} label={k} value={typeof v === 'number' ? round(v, 2) : v} />
+          ))}
+        </div>
+      </div>
+
+      {last && (
+        <div className="mt-3 border-t pt-3">
+          <SectionTitle>ผลล่าสุด (บันทึกอัตโนมัติ)</SectionTitle>
+          <div className="text-[11px] text-gray-500 mb-1">บันทึกเมื่อ {fmtTime(last.at)}</div>
+          <div className="flex flex-col gap-1">
+            {Object.entries(last.results || {}).map(([k, v]) => (
+              <ResultRow key={k} label={k} value={typeof v === 'number' ? round(v, 2) : v} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {def.refs?.length ? (
+        <div className="mt-3 text-[11px] text-gray-500 leading-snug">
+          {def.refs.join(' • ')}
+        </div>
+      ) : null}
+    </Card>
+  );
+}

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,0 +1,29 @@
+'use client';
+import { cls } from '../lib/utils.js';
+
+export default function Card({ children, actions, title, subtitle, isFav, onToggleFav }) {
+  return (
+    <div className="rounded-2xl border border-gray-200 bg-white shadow-sm p-4">
+      <div className="flex items-start justify-between mb-3">
+        <div>
+          <div className="text-base font-semibold">{title}</div>
+          {subtitle && <div className="text-xs text-gray-500">{subtitle}</div>}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            aria-label={isFav ? 'Remove favorite' : 'Add favorite'}
+            onClick={onToggleFav}
+            className={cls(
+              'rounded-full px-3 py-1 text-xs border',
+              isFav ? 'bg-yellow-100 border-yellow-300' : 'bg-white border-gray-300'
+            )}
+          >
+            {isFav ? '★ Saved' : '☆ Save'}
+          </button>
+          {actions}
+        </div>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/components/Chip.jsx
+++ b/src/components/Chip.jsx
@@ -1,0 +1,16 @@
+'use client';
+import { cls } from '../lib/utils.js';
+
+export default function Chip({ active, children, onClick }) {
+  return (
+    <button
+      onClick={onClick}
+      className={cls(
+        'px-3 py-1 rounded-full text-sm border',
+        active ? 'bg-black text-white border-black' : 'bg-white text-gray-700 border-gray-300'
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/InputField.jsx
+++ b/src/components/InputField.jsx
@@ -1,0 +1,40 @@
+'use client';
+import { cls } from '../lib/utils.js';
+
+export default function InputField({ field, value, onChange }) {
+  const common = {
+    id: field.key,
+    value: value ?? '',
+    onChange: (e) => onChange(field.key, e.target.value),
+    className: 'w-full px-3 py-2 rounded-xl border border-gray-300 focus:outline-none focus:ring-2 focus:ring-black/20',
+  };
+  if (field.type === 'select') {
+    return (
+      <div className="flex flex-col gap-1">
+        <label htmlFor={field.key} className="text-sm text-gray-700">{field.label}</label>
+        <select {...common}>
+          <option value="">—</option>
+          {field.options?.map((o) => (
+            <option key={o} value={o}>{o}</option>
+          ))}
+        </select>
+      </div>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-1">
+      <label htmlFor={field.key} className="text-sm text-gray-700">
+        {field.label}
+      </label>
+      <input
+        type={field.type || 'text'}
+        inputMode={field.type === 'number' ? 'decimal' : undefined}
+        min={field.min}
+        max={field.max}
+        step={field.step}
+        placeholder={field.placeholder}
+        {...common}
+      />
+    </div>
+  );
+}

--- a/src/components/MedCalcDashboard.jsx
+++ b/src/components/MedCalcDashboard.jsx
@@ -1,0 +1,106 @@
+'use client';
+import { useMemo, useState } from 'react';
+import { CALCULATORS } from '../data/calculators.js';
+import { CATEGORIES } from '../data/categories.js';
+import { useLocalStorage, cls } from '../lib/utils.js';
+import Chip from './Chip.jsx';
+import CalculatorCard from './CalculatorCard.jsx';
+import { runSelfTests } from '../lib/selfTests.js';
+
+if (typeof window !== 'undefined') {
+  runSelfTests();
+}
+
+export default function MedCalcDashboard() {
+  const [query, setQuery] = useState('');
+  const [activeCat, setActiveCat] = useState('All');
+  const [favorites, setFavorites] = useLocalStorage('medcalc.favorites', []);
+  const [valuesMap, setValuesMap] = useLocalStorage('medcalc.values', {});
+  const [lastResults, setLastResults] = useLocalStorage('medcalc.lastResults', {});
+
+  const list = useMemo(() => {
+    let arr = CALCULATORS;
+    if (activeCat === 'Favorites') {
+      arr = arr.filter((c) => favorites.includes(c.id));
+    } else if (activeCat !== 'All') {
+      arr = arr.filter((c) => c.category === activeCat);
+    }
+    if (query.trim()) {
+      const q = query.toLowerCase();
+      arr = arr.filter(
+        (c) => c.name.toLowerCase().includes(q) || c.category.toLowerCase().includes(q) || c.id.toLowerCase().includes(q)
+      );
+    }
+    return arr;
+  }, [query, activeCat, favorites]);
+
+  const resetAll = () => {
+    if (!confirm('Clear all inputs and favorites?')) return;
+    setValuesMap({});
+    setFavorites([]);
+    setLastResults({});
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 text-gray-900">
+      <header className="sticky top-0 z-20 bg-white/90 backdrop-blur border-b border-gray-200">
+        <div className="px-4 py-3 flex items-center gap-3">
+          <div className="flex-1">
+            <div className="text-lg font-bold">MedCalc Dashboard</div>
+            <div className="text-xs text-gray-500">เครื่องคิดเลขการแพทย์ – มือถือเป็นหลัก</div>
+          </div>
+          <button onClick={resetAll} className="text-xs rounded-full border px-3 py-1 bg-white">Reset</button>
+        </div>
+        <div className="px-4 pb-3">
+          <div className="flex items-center gap-2 bg-gray-100 rounded-xl px-3 py-2">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M21 21l-4.3-4.3" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/><circle cx="10" cy="10" r="6" stroke="currentColor" strokeWidth="2" fill="none"/></svg>
+            <input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="ค้นหาชื่อสูตร/หมวด... (เช่น MAP, AG, BMI)"
+              className="bg-transparent outline-none w-full text-sm"
+            />
+          </div>
+        </div>
+        <div className="px-4 pb-2 overflow-x-auto no-scrollbar">
+          <div className="flex gap-2 w-max">
+            {CATEGORIES.map((c) => (
+              <Chip key={c.key} active={activeCat === c.key} onClick={() => setActiveCat(c.key)}>
+                {c.label}
+              </Chip>
+            ))}
+          </div>
+        </div>
+      </header>
+
+      <main className="p-4 grid grid-cols-1 gap-4 pb-28">
+        {list.length === 0 ? (
+          <div className="text-sm text-gray-500">ไม่พบเครื่องคิดเลขที่ตรงกับคำค้น</div>
+        ) : (
+          list.map((def) => (
+            <CalculatorCard
+              key={def.id}
+              def={def}
+              values={valuesMap[def.id] || {}}
+              setValues={(updater) =>
+                setValuesMap((prev) => ({ ...prev, [def.id]: typeof updater === 'function' ? updater(prev[def.id] || {}) : updater }))
+              }
+              favorites={favorites}
+              setFavorites={setFavorites}
+              last={lastResults[def.id]}
+              setLast={(entry) => setLastResults((p) => ({ ...p, [def.id]: entry }))}
+            />
+          ))
+        )}
+      </main>
+
+      <nav className="fixed bottom-0 inset-x-0 bg-white border-t border-gray-200 shadow-[0_-4px_12px_rgba(0,0,0,0.04)]">
+        <div className="grid grid-cols-3 text-xs">
+          <button onClick={() => setActiveCat('All')} className={cls('py-3', activeCat === 'All' && 'text-black font-semibold')}>ทั้งหมด</button>
+          <button onClick={() => setActiveCat('Favorites')} className={cls('py-3', activeCat === 'Favorites' && 'text-black font-semibold')}>ที่ชอบ</button>
+          <button onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })} className="py-3">ขึ้นบน</button>
+        </div>
+      </nav>
+    </div>
+  );
+}

--- a/src/components/ResultRow.jsx
+++ b/src/components/ResultRow.jsx
@@ -1,0 +1,10 @@
+'use client';
+
+export default function ResultRow({ label, value, unit }) {
+  return (
+    <div className="flex justify-between text-sm">
+      <div className="text-gray-600">{label}</div>
+      <div className="font-semibold">{value}{unit ? ` ${unit}` : ''}</div>
+    </div>
+  );
+}

--- a/src/components/SectionTitle.jsx
+++ b/src/components/SectionTitle.jsx
@@ -1,0 +1,5 @@
+'use client';
+
+export default function SectionTitle({ children }) {
+  return <div className="text-xs font-medium text-gray-500 uppercase tracking-wider px-1 mb-1">{children}</div>;
+}

--- a/src/data/calculators.js
+++ b/src/data/calculators.js
@@ -1,0 +1,178 @@
+export const CALCULATORS = [
+  {
+    id: 'map',
+    name: 'Mean Arterial Pressure (MAP)',
+    category: 'Cardio',
+    fields: [
+      { key: 'sbp', label: 'SBP (mmHg)', type: 'number', min: 0, step: 1 },
+      { key: 'dbp', label: 'DBP (mmHg)', type: 'number', min: 0, step: 1 },
+    ],
+    compute: ({ sbp, dbp }) => {
+      if (!sbp && sbp !== 0) return { MAP: null };
+      if (!dbp && dbp !== 0) return { MAP: null };
+      const MAP = (Number(sbp) + 2 * Number(dbp)) / 3;
+      const status = MAP < 65 ? '\u26A0\uFE0F Low perfusion risk (<65)' : '\u2705 Adequate (\u226565)';
+      return { MAP, status };
+    },
+    formula: 'MAP = (SBP + 2×DBP) / 3',
+    refs: ['Common approximation for MAP in sinus rhythm'],
+    notes: 'ใช้กับ regular rhythm; ภาวะชีพจรไม่สม่ำเสมอควรวัดซ้ำหลายครั้งและใช้ค่าเฉลี่ย'
+  },
+  {
+    id: 'shockIndex',
+    name: 'Shock Index',
+    category: 'Cardio',
+    fields: [
+      { key: 'hr', label: 'HR (bpm)', type: 'number', min: 0, step: 1 },
+      { key: 'sbp', label: 'SBP (mmHg)', type: 'number', min: 0, step: 1 },
+    ],
+    compute: ({ hr, sbp }) => {
+      if (!hr || !sbp) return { SI: null };
+      const SI = Number(hr) / Number(sbp);
+      const status = SI >= 0.9 ? '\u26A0\uFE0F Elevated (\u22650.9)' : '\u2705 Normal';
+      return { SI, status };
+    },
+    formula: 'SI = HR / SBP',
+    refs: ['Shock Index utility in triage'],
+  },
+  {
+    id: 'crcl',
+    name: 'Creatinine Clearance (Cockcroft–Gault)',
+    category: 'Renal/Fluid',
+    fields: [
+      { key: 'age', label: 'Age (years)', type: 'number', min: 1, step: 1 },
+      { key: 'weight', label: 'Weight (kg)', type: 'number', min: 1, step: 0.1 },
+      { key: 'scr', label: 'Serum Cr (mg/dL)', type: 'number', min: 0, step: 0.01 },
+      { key: 'sex', label: 'Sex', type: 'select', options: ['Male', 'Female'] },
+    ],
+    compute: ({ age, weight, scr, sex }) => {
+      if (!age || !weight || !scr || !sex) return { CrCl: null };
+      const base = ((140 - Number(age)) * Number(weight)) / (72 * Number(scr));
+      const CrCl = sex === 'Female' ? base * 0.85 : base;
+      return { CrCl };
+    },
+    formula: 'CrCl = ((140 − age) × weight) / (72 × SCr); ×0.85 if female',
+    refs: ['Cockcroft–Gault (1976)'],
+    notes: 'โดยทั่วไปใช้ actual body weight; ผู้ป่วยอ้วนมากพิจารณา Adjusted BW ตามแนวทางของยา'
+  },
+  {
+    id: 'anionGap',
+    name: 'Anion Gap (+ Albumin-corrected)',
+    category: 'Renal/Fluid',
+    fields: [
+      { key: 'na', label: 'Na (mEq/L)', type: 'number', min: 50, max: 200, step: 1 },
+      { key: 'cl', label: 'Cl (mEq/L)', type: 'number', min: 50, max: 200, step: 1 },
+      { key: 'hco3', label: 'HCO₃⁻ (mEq/L)', type: 'number', min: 0, max: 60, step: 1 },
+      { key: 'alb', label: 'Albumin (g/dL, optional)', type: 'number', min: 0, max: 6, step: 0.1 },
+    ],
+    compute: ({ na, cl, hco3, alb }) => {
+      if (!na && na !== 0) return { AG: null };
+      if (!cl && cl !== 0) return { AG: null };
+      if (!hco3 && hco3 !== 0) return { AG: null };
+      const AG = Number(na) - (Number(cl) + Number(hco3));
+      const AGcorr = alb ? AG + 2.5 * (4 - Number(alb)) : null;
+      return { AG, AGcorr };
+    },
+    formula: 'AG = Na − (Cl + HCO₃⁻)\nAG(corrected) = AG + 2.5 × (4 − albumin)',
+    refs: ['Traditional AG calculation; albumin correction 2.5 per 1 g/dL'],
+  },
+  {
+    id: 'corrCalcium',
+    name: 'Corrected Calcium',
+    category: 'Renal/Fluid',
+    fields: [
+      { key: 'ca', label: 'Total Ca (mg/dL)', type: 'number', min: 0, step: 0.1 },
+      { key: 'alb', label: 'Albumin (g/dL)', type: 'number', min: 0, step: 0.1 },
+    ],
+    compute: ({ ca, alb }) => {
+      if (!ca || !alb) return { CaCorrected: null };
+      const CaCorrected = Number(ca) + 0.8 * (4 - Number(alb));
+      return { CaCorrected };
+    },
+    formula: 'Ca(corrected) = Ca + 0.8 × (4 − albumin)',
+    refs: ['Payne formula'],
+  },
+  {
+    id: 'bmi',
+    name: 'Body Mass Index (BMI)',
+    category: 'General',
+    fields: [
+      { key: 'height', label: 'Height (cm)', type: 'number', min: 50, max: 260, step: 0.1 },
+      { key: 'weight', label: 'Weight (kg)', type: 'number', min: 1, max: 500, step: 0.1 },
+    ],
+    compute: ({ height, weight }) => {
+      if (!height || !weight) return { BMI: null };
+      const m = Number(height) / 100;
+      const BMI = Number(weight) / (m * m);
+      let cat = '';
+      if (BMI < 18.5) cat = 'Underweight';
+      else if (BMI < 25) cat = 'Normal';
+      else if (BMI < 30) cat = 'Overweight';
+      else cat = 'Obesity';
+      return { BMI, category: cat };
+    },
+    formula: 'BMI = weight / height² (kg/m²)',
+    refs: ['WHO BMI categories'],
+  },
+  {
+    id: 'bsa',
+    name: 'Body Surface Area (Mosteller)',
+    category: 'General',
+    fields: [
+      { key: 'height', label: 'Height (cm)', type: 'number', min: 50, max: 260, step: 0.1 },
+      { key: 'weight', label: 'Weight (kg)', type: 'number', min: 1, max: 500, step: 0.1 },
+    ],
+    compute: ({ height, weight }) => {
+      if (!height || !weight) return { BSA: null };
+      const BSA = Math.sqrt((Number(height) * Number(weight)) / 3600);
+      return { BSA };
+    },
+    formula: 'BSA = \u221A((height(cm) × weight(kg)) / 3600)',
+    refs: ['Mosteller 1987'],
+  },
+  {
+    id: 'pfratio',
+    name: 'P/F Ratio',
+    category: 'ICU/Resp',
+    fields: [
+      { key: 'pao2', label: 'PaO₂ (mmHg)', type: 'number', min: 0, step: 1 },
+      { key: 'fio2', label: 'FiO₂ (% or fraction)', type: 'text', placeholder: 'e.g. 40 or 0.4' },
+    ],
+    compute: ({ pao2, fio2 }) => {
+      if (!pao2 || !fio2) return { PFratio: null };
+      let f = String(fio2).trim();
+      let frac = parseFloat(f);
+      if (Number.isNaN(frac)) return { PFratio: null };
+      if (frac > 1.2) frac = frac / 100;
+      if (frac <= 0) return { PFratio: null };
+      const PFratio = Number(pao2) / frac;
+      let sev = '';
+      if (PFratio < 100) sev = 'Severe';
+      else if (PFratio < 200) sev = 'Moderate';
+      else if (PFratio < 300) sev = 'Mild';
+      else sev = 'Normal';
+      return { PFratio, severity: sev };
+    },
+    formula: 'P/F = PaO₂ / FiO₂ (FiO₂ เป็นสัดส่วน 0–1)',
+    refs: ['Berlin ARDS categories for P/F'],
+  },
+  {
+    id: 'fwd',
+    name: 'Free Water Deficit',
+    category: 'Renal/Fluid',
+    fields: [
+      { key: 'sex', label: 'Sex', type: 'select', options: ['Male', 'Female'] },
+      { key: 'weight', label: 'Weight (kg)', type: 'number', min: 1, step: 0.1 },
+      { key: 'na', label: 'Na (mEq/L)', type: 'number', min: 100, max: 200, step: 1 },
+    ],
+    compute: ({ sex, weight, na }) => {
+      if (!sex || !weight || !na) return { DeficitL: null };
+      const coef = sex === 'Male' ? 0.6 : 0.5;
+      const TBW = coef * Number(weight);
+      const DeficitL = TBW * (Number(na) / 140 - 1);
+      return { TBW, DeficitL };
+    },
+    formula: 'TBW ≈ 0.6(M) / 0.5(F) × weight;\nDeficit = TBW × ((Na/140) − 1)',
+    refs: ['Traditional hypernatremia water deficit estimate'],
+  },
+];

--- a/src/data/categories.js
+++ b/src/data/categories.js
@@ -1,0 +1,8 @@
+export const CATEGORIES = [
+  { key: 'All', label: 'ทั้งหมด' },
+  { key: 'Favorites', label: 'ที่ชอบ' },
+  { key: 'Cardio', label: 'หัวใจ' },
+  { key: 'Renal/Fluid', label: 'ไต/ของเหลว' },
+  { key: 'ICU/Resp', label: 'ไอซียู/หายใจ' },
+  { key: 'General', label: 'ทั่วไป' },
+];

--- a/src/lib/selfTests.js
+++ b/src/lib/selfTests.js
@@ -1,0 +1,51 @@
+import { CALCULATORS } from '../data/calculators.js';
+
+export function runSelfTests() {
+  try {
+    const find = (id) => CALCULATORS.find((c) => c.id === id);
+    const approx = (a, b, tol = 1e-2) => Math.abs(a - b) <= tol;
+
+    {
+      const out = find('map').compute({ sbp: 120, dbp: 80 });
+      if (!approx(out.MAP, 93.3333)) throw new Error('MAP test failed');
+    }
+
+    {
+      const out = find('shockIndex').compute({ hr: 90, sbp: 120 });
+      if (!approx(out.SI, 0.75)) throw new Error('Shock Index value wrong');
+      if (out.status !== '\u2705 Normal') throw new Error('Shock Index status wrong');
+    }
+
+    {
+      const out = find('crcl').compute({ age: 40, weight: 70, scr: 1.0, sex: 'Male' });
+      if (!approx(out.CrCl, 97.22, 0.2)) throw new Error('CrCl test failed');
+    }
+
+    {
+      const out = find('anionGap').compute({ na: 140, cl: 100, hco3: 24 });
+      if (!approx(out.AG, 16)) throw new Error('Anion gap test failed');
+    }
+
+    {
+      const out = find('pfratio').compute({ pao2: 80, fio2: 0.4 });
+      if (!approx(out.PFratio, 200)) throw new Error('P/F value failed');
+      if (out.severity !== 'Mild') throw new Error('P/F severity mapping failed');
+    }
+
+    {
+      const out = find('bmi').compute({ height: 180, weight: 81 });
+      if (!approx(out.BMI, 25, 0.05)) throw new Error('BMI value failed');
+      if (out.category !== 'Overweight') throw new Error('BMI category failed');
+    }
+
+    {
+      const out = find('bsa').compute({ height: 170, weight: 65 });
+      if (!approx(out.BSA, 1.73, 0.03)) throw new Error('BSA value failed');
+    }
+
+    console.info('MedCalc self-tests: all passed ✅');
+  } catch (e) {
+    console.warn('MedCalc self-tests: failed ❌', e);
+    process.exitCode = 1;
+  }
+}

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,0 +1,53 @@
+export function cls(...a) {
+  return a.filter(Boolean).join(' ');
+}
+
+import { useEffect, useState } from 'react';
+
+export function useLocalStorage(key, initialValue) {
+  const [value, setValue] = useState(() => {
+    try {
+      const item = localStorage.getItem(key);
+      return item ? JSON.parse(item) : initialValue;
+    } catch {
+      return initialValue;
+    }
+  });
+  useEffect(() => {
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch {}
+  }, [key, value]);
+  return [value, setValue];
+}
+
+export function round(n, dp = 2) {
+  if (n === null || n === undefined || Number.isNaN(n)) return '-';
+  const f = Math.pow(10, dp);
+  return Math.round((n + Number.EPSILON) * f) / f;
+}
+
+export async function copyToClipboard(text) {
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      /* fall through to legacy method */
+    }
+  }
+  try {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.style.position = 'fixed';
+    textarea.style.left = '-9999px';
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textarea);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/selfTests.js
+++ b/src/selfTests.js
@@ -1,0 +1,2 @@
+import { runSelfTests } from './lib/selfTests.js';
+runSelfTests();


### PR DESCRIPTION
## Summary
- split monolithic dashboard into modular components and utilities
- centralize calculator definitions and categories
- add self-test script and package metadata
- implement clipboard helper and wire copy button to it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c13504340832b8c728ea66043162f